### PR TITLE
Feat: 댓글 프론트 연결 #42

### DIFF
--- a/src/components/board/BoardDetailLayout.jsx
+++ b/src/components/board/BoardDetailLayout.jsx
@@ -29,20 +29,25 @@ export const BoardDetailLayout = ({
   onBookmark,
 
 }) => {
-  return (
-    <div className="community-detail-container">
-      {children}
-      <BoardTagShareBar
-        tags={post.tags}
-        likes={likeCount}
-        isLiked={isLiked}
-        bookmarks={bookmarkCount}
-        isBookmarked={isBookmarked}
-        onLikeToggle={onLike}
-        onBookmarkToggle={onBookmark}
-        postId={post.postId}
-      />
-      <CommentSection postId={post.postId} comments={post.comments || []} />
-    </div>
-  );
+    return (
+        <div className="community-detail-container">
+            {children}
+            <BoardTagShareBar
+                tags={post.tags}
+                likes={likeCount}
+                isLiked={isLiked}
+                bookmarks={bookmarkCount}
+                isBookmarked={isBookmarked}
+                onLikeToggle={onLike}
+                onBookmarkToggle={onBookmark}
+                postId={post.postId}
+            />
+            <CommentSection
+                boardType={post.boardType}
+                boardPostId={post.communityId || post.id}
+                postId={post.postId}
+                comments={post.comments || []}
+            />
+        </div>
+    );
 };

--- a/src/components/comment/CommentItem.jsx
+++ b/src/components/comment/CommentItem.jsx
@@ -3,8 +3,8 @@ import { useLikeBookmark } from "../../hooks/useLikeBookmark";
 import { useInput } from "../../hooks/useInput";
 import { isAuthor } from "../../utils/auth";
 import ReportModal from "../common/ReportModal";
-import {submitReport} from "../../services/reportApi.js";
-
+import { submitReport } from "../../services/reportApi.js";
+import '../../styles/components/comment/CommentSection.css'
 
 /**
  * @typedef {Object} CommentItemProps
@@ -13,16 +13,30 @@ import {submitReport} from "../../services/reportApi.js";
  * @property {function} [onLike]
  * @property {function} [onDelete]
  * @property {function} [onEdit]
+ * @property {function} [onLoadReplies]
+ * @property {function} [onLoadMoreReplies]
  * @property {number} [depth]
  * @property {object} user
- * @property {Array} [allComments]
+ * @property {Array} [allComments] - 기존 호환성을 위해 유지
+ * @property {string|number} postId
+ * @property {object} [repliesData]
+ * @property {boolean} [repliesLoading]
  */
 
 const CommentItem = (props) => {
-  const { comment, user: currentUser, allComments = [] } = props;
+  const {
+    comment,
+    user: currentUser,
+    allComments = [],
+    postId,
+    onLoadReplies,
+    onLoadMoreReplies,
+    repliesData,
+    repliesLoading
+  } = props;
+
   const {
     id,
-    postId,
     nickname,
     profileImageUrl,
     parentCommentId,
@@ -39,6 +53,7 @@ const CommentItem = (props) => {
   const [showReplies, setShowReplies] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [showReportModal, setShowReportModal] = useState(false);
+  const [replySubmitting, setReplySubmitting] = useState(false);
 
   const {
     value: replyContent,
@@ -58,22 +73,66 @@ const CommentItem = (props) => {
     initialLikeCount: likeCount,
     initialLiked: hasLiked,
   });
+
   const depth = props.depth || 1;
+
+  console.log('CommentItem 렌더링:', {
+    commentId: id,
+    nickname,
+    replyCount,
+    parentCommentId,
+    depth,
+    fullComment: comment
+  });
+
   // 댓글 작성자 판별 (userId 기준)
   const isMine = currentUser && currentUser.userId === userId;
 
-  // 대댓글 추출 (parentCommentId === 현재 댓글 id)
-  const commentReplies = allComments.filter((c) => c.parentCommentId === id);
+  // 새로운 방식의 대댓글 데이터 사용 (repliesData가 있는 경우)
+  // 없으면 기존 방식 사용 (하위 호환성)
+  let commentReplies = [];
+  let hasMoreReplies = false;
+
+  if (repliesData) {
+    // 새로운 API 연동 방식
+    commentReplies = repliesData.comments || [];
+    hasMoreReplies = repliesData.hasNext || false;
+  } else {
+    // 기존 방식 (allComments에서 필터링)
+    commentReplies = allComments.filter((c) => c.parentCommentId === id);
+  }
+
   const showRepliesForThis = depth === 1 ? showReplies : true;
 
-  const handleReplySubmit = (e) => {
+  /**
+   * 대댓글 작성
+   */
+  const handleReplySubmit = async (e) => {
     e.preventDefault();
-    if (!replyContent.trim()) return;
-    if (props.onReplyAdd) {
-      props.onReplyAdd(id, replyContent);
+    if (!replyContent.trim() || replySubmitting) return;
+
+    setReplySubmitting(true);
+    try {
+      if (props.onReplyAdd) {
+        await props.onReplyAdd(id, replyContent);
+      }
+      resetReply();
+      setShowReplyInput(false);
+
+      // 대댓글을 작성한 후 처리
+      if (!showReplies) {
+        // 답글보기가 열려있지 않다면 답글을 가져오고 보여줌
+        if (onLoadReplies) {
+          onLoadReplies(id);
+        }
+        setShowReplies(true);
+      }
+      // showReplies가 이미 true라면 useComments에서 repliesData를 업데이트해줌
+    } catch (err) {
+      // 에러는 부모에서 처리됨
+    } finally {
+      setReplySubmitting(false);
     }
-    resetReply();
-    setShowReplyInput(false);
   };
 
   const handleLikeClick = () => {
@@ -88,18 +147,54 @@ const CommentItem = (props) => {
     setIsEditing(true);
   };
 
-  const handleEditSave = () => {
-    if (props.onEdit) {
-      props.onEdit(id, editContent);
+  const handleEditSave = async () => {
+    try {
+      if (props.onEdit) {
+        const isReply = depth > 1;
+        const parentId = isReply ? parentCommentId : null;
+        await props.onEdit(id, editContent, isReply, parentId);
+      }
+      setIsEditing(false);
+    } catch (err) {
+      // 에러는 부모에서 처리됨
     }
-    setIsEditing(false);
   };
 
-  const handleDelete = () => {
+  const handleDelete = async () => {
     if (window.confirm("정말로 이 댓글을 삭제하시겠습니까?")) {
-      if (props.onDelete) {
-        props.onDelete(id);
+      try {
+        if (props.onDelete) {
+          const isReply = depth > 1;
+          const parentId = isReply ? parentCommentId : null;
+          await props.onDelete(id, isReply, parentId);
+        }
+      } catch (err) {
+        // 에러는 부모에서 처리됨
       }
+    }
+  };
+
+  /**
+   * 대댓글 보기/숨기기
+   */
+  const handleToggleReplies = () => {
+    if (!showReplies) {
+      // 처음 대댓글을 보는 경우 로드 (새로운 API 방식)
+      if (onLoadReplies && commentReplies.length === 0 && replyCount > 0) {
+        onLoadReplies(id);
+      }
+      setShowReplies(true);
+    } else {
+      setShowReplies(false);
+    }
+  };
+
+  /**
+   * 더 많은 대댓글 로드
+   */
+  const handleLoadMoreReplies = () => {
+    if (onLoadMoreReplies) {
+      onLoadMoreReplies(id);
     }
   };
 
@@ -113,16 +208,15 @@ const CommentItem = (props) => {
       console.log("CommentItem - reportData.reportTarget:", reportData.reportTarget);
 
       const result = await submitReport(reportData);
-
       console.log("댓글 신고 성공:", result);
     } catch (error) {
       console.error("댓글 신고 오류:", error);
-
       throw error;
     }
   };
+
   return (
-      <div className="community-detail-comment-item">
+      <div className={`community-detail-comment-item ${depth > 1 ? 'comment-reply' : ''}`}>
         <div className="comment-author-row">
           <img
               src={profileImageUrl}
@@ -147,6 +241,7 @@ const CommentItem = (props) => {
             )}
           </div>
         </div>
+
         <div className="comment-content">
           {isEditing ? (
               <div className="d-flex align-items-center">
@@ -174,6 +269,7 @@ const CommentItem = (props) => {
               initialContent
           )}
         </div>
+
         <div className="comment-actions">
           <button className="btn-comment-like" onClick={handleLikeClick}>
             <i
@@ -181,12 +277,16 @@ const CommentItem = (props) => {
             ></i>{" "}
             {likeCountState}
           </button>
-          <button
-              className="btn-comment-reply"
-              onClick={() => setShowReplyInput((v) => !v)}
-          >
-            답글
-          </button>
+
+          {depth === 1 && (
+              <button
+                  className="btn-comment-reply"
+                  onClick={() => setShowReplyInput(prev => !prev)}
+              >
+                답글
+              </button>
+          )}
+
           {isMine && (
               <>
                 <button
@@ -203,26 +303,32 @@ const CommentItem = (props) => {
                 </button>
               </>
           )}
-          {depth === 1 && commentReplies.length > 0 && !showReplies && (
+
+          {/* 대댓글 보기/숨기기 버튼 (부모 댓글만) */}
+          {depth === 1 && (replyCount > 0 || (repliesData && repliesData.comments && repliesData.comments.length > 0)) && !showReplies && (
               <button
                   className="btn btn-link btn-sm text-primary ms-2"
                   style={{ textDecoration: "underline" }}
-                  onClick={() => setShowReplies(true)}
+                  onClick={handleToggleReplies}
+                  disabled={repliesLoading}
               >
-                답글 보기({commentReplies.length})
+                {repliesLoading ? '로딩 중...' : `답글 보기(${replyCount})`}
               </button>
           )}
-          {depth === 1 && showReplies && commentReplies.length > 0 && (
+
+          {depth === 1 && showReplies && (replyCount > 0 || (repliesData && repliesData.comments && repliesData.comments.length > 0)) && (
               <button
-                  className="btn btn-link btn-sm text-secondary mt-1 ms-2"
+                  className="btn btn-link btn-sm text-secondary ms-2"
                   style={{ textDecoration: "underline" }}
-                  onClick={() => setShowReplies(false)}
+                  onClick={handleToggleReplies}
               >
                 답글 숨기기
               </button>
           )}
         </div>
-        {showReplyInput && (
+
+        {/* 대댓글 입력 폼 */}
+        {showReplyInput && depth === 1 && (
             <form
                 className="comment-reply-form d-flex mt-2"
                 onSubmit={handleReplySubmit}
@@ -234,32 +340,77 @@ const CommentItem = (props) => {
                   onChange={onReplyChange}
                   placeholder="답글을 입력하세요"
                   autoFocus
+                  disabled={replySubmitting}
               />
-              <button type="submit" className="btn btn-primary btn-sm">
-                등록
+              <button
+                  type="submit"
+                  className="btn btn-primary btn-sm"
+                  disabled={replySubmitting || !replyContent.trim()}
+              >
+                {replySubmitting ? '등록 중...' : '등록'}
               </button>
             </form>
         )}
+
+        {/* 대댓글 목록 */}
         {showRepliesForThis && commentReplies.length > 0 && (
             <div className="comment-replies">
-              {commentReplies
-                  .slice()
-                  .sort((a, b) => a.id - b.id)
-                  .map((reply) => (
-                      <CommentItem
-                          key={reply.id}
-                          comment={reply}
-                          user={currentUser}
-                          onReplyAdd={props.onReplyAdd}
-                          onLike={props.onLike}
-                          onDelete={props.onDelete}
-                          onEdit={props.onEdit}
-                          depth={depth + 1}
-                          allComments={allComments}
-                      />
-                  ))}
+              {repliesLoading && commentReplies.length === 0 ? (
+                  <div className="text-center py-2">
+                    <div className="spinner-border spinner-border-sm" role="status">
+                      <span className="visually-hidden">대댓글을 불러오는 중...</span>
+                    </div>
+                  </div>
+              ) : (
+                  <>
+                    {commentReplies
+                        .slice()
+                        .sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt))
+                        .map((reply) => (
+                            <CommentItem
+                                key={reply.id}
+                                comment={reply}
+                                user={currentUser}
+                                postId={postId}
+                                onReplyAdd={props.onReplyAdd}
+                                onLike={props.onLike}
+                                onDelete={props.onDelete}
+                                onEdit={props.onEdit}
+                                depth={depth + 1}
+                                allComments={allComments}
+                            />
+                        ))}
+
+                    {/* 더 많은 대댓글 로드 버튼 (새로운 API 방식에서만) */}
+                    {hasMoreReplies && onLoadMoreReplies && (
+                        <div className="text-center py-2">
+                          <button
+                              className="btn-load-more-replies"
+                              onClick={handleLoadMoreReplies}
+                              disabled={repliesLoading}
+                          >
+                            {repliesLoading ? (
+                                <div className="load-more-loading-small">
+                                  <div className="spinner-small"></div>
+                                  <span>로딩 중...</span>
+                                </div>
+                            ) : (
+                                <div className="load-more-content-small">
+                                  <svg className="load-more-icon-small" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                                  </svg>
+                                  <span>더 많은 답글 보기</span>
+                                </div>
+                            )}
+                          </button>
+                        </div>
+                    )}
+                  </>
+              )}
             </div>
         )}
+
+        {/* 신고 모달 */}
         <ReportModal
             show={showReportModal}
             onHide={() => setShowReportModal(false)}

--- a/src/components/comment/CommentItem.jsx
+++ b/src/components/comment/CommentItem.jsx
@@ -76,15 +76,6 @@ const CommentItem = (props) => {
 
   const depth = props.depth || 1;
 
-  console.log('CommentItem 렌더링:', {
-    commentId: id,
-    nickname,
-    replyCount,
-    parentCommentId,
-    depth,
-    fullComment: comment
-  });
-
   // 댓글 작성자 판별 (userId 기준)
   const isMine = currentUser && currentUser.userId === userId;
 
@@ -204,13 +195,8 @@ const CommentItem = (props) => {
 
   const handleReportSubmit = async (reportData) => {
     try {
-      console.log("CommentItem - 받은 reportData:", reportData);
-      console.log("CommentItem - reportData.reportTarget:", reportData.reportTarget);
-
       const result = await submitReport(reportData);
-      console.log("댓글 신고 성공:", result);
     } catch (error) {
-      console.error("댓글 신고 오류:", error);
       throw error;
     }
   };

--- a/src/components/comment/CommentSection.jsx
+++ b/src/components/comment/CommentSection.jsx
@@ -1,97 +1,220 @@
-import React, { useRef, useEffect, useCallback } from "react";
+import React, { useState } from "react";
 import { CommentItem } from "./CommentItem";
 import { useInput } from "../../hooks/useInput";
 import { useAuth } from "../../context/AuthContext";
 import { useComments } from "../../hooks/useComments";
+import '../../styles/components/comment/CommentSection.css';
 
 /**
- * @typedef {Object} CommentSectionProps
- * @property {string|number} postId
- * @property {Array} comments
- */
-
-/**
- * 댓글 전체 컴포넌트 (자체적으로 상태 및 로직 관리)
- * @param {CommentSectionProps} props
+ * 댓글 전체 컴포넌트 (백엔드 API 연동 - 더보기 버튼 방식)
  */
 const CommentSection = ({ postId, comments: initialComments = [] }) => {
   const { value, onChange, reset } = useInput("");
-  const loaderRef = useRef(null);
   const { user } = useAuth();
+  const [submitLoading, setSubmitLoading] = useState(false);
+
   const {
     comments,
+    loading,
+    initialLoaded,
+    error,
+    hasNext,
+    repliesData,
+    repliesLoading,
     handleCommentAdd,
     handleReplyAdd,
     handleCommentEdit,
     handleCommentDelete,
-    setComments,
-  } = useComments(initialComments, postId);
-  const [commentsToShow, setCommentsToShow] = React.useState(5);
+    loadMoreComments,
+    loadReplies,
+    loadMoreReplies,
+  } = useComments(postId);
 
-  useEffect(() => {
-    setComments(initialComments);
-  }, [initialComments, setComments]);
-
-  const handleAdd = (e) => {
+  /**
+   * 댓글 작성 처리
+   */
+  const handleAdd = async (e) => {
     e.preventDefault();
-    if (!value.trim()) return;
-    handleCommentAdd(value);
-    reset();
+    if (!value.trim() || submitLoading) return;
+
+    setSubmitLoading(true);
+    try {
+      await handleCommentAdd(value);
+      reset();
+
+      // 간단한 알림 (alert 사용)
+      if (hasNext) {
+        alert('댓글이 작성되었습니다. 모든 댓글을 보려면 "더 많은 댓글 보기"를 눌러주세요.');
+      }
+    } catch (err) {
+      alert(err.message);
+    } finally {
+      setSubmitLoading(false);
+    }
   };
 
-  const handleObserver = useCallback(
-    (entries) => {
-      const target = entries[0];
-      if (target.isIntersecting) {
-        setCommentsToShow((prev) => Math.min(prev + 5, comments.length));
-      }
-    },
-    [comments.length]
-  );
+  /**
+   * 대댓글 작성 처리
+   */
+  const handleReplyAddWrapper = async (parentCommentId, content) => {
+    try {
+      await handleReplyAdd(parentCommentId, content);
+    } catch (err) {
+      alert(err.message);
+      throw err;
+    }
+  };
 
-  useEffect(() => {
-    if (comments.length <= 5) return;
-    const option = { root: null, rootMargin: "0px", threshold: 0.1 };
-    const observer = new window.IntersectionObserver(handleObserver, option);
-    if (loaderRef.current) observer.observe(loaderRef.current);
-    return () => observer.disconnect();
-  }, [handleObserver, comments.length]);
+  /**
+   * 댓글 수정 처리
+   */
+  const handleCommentEditWrapper = async (commentId, content, isReply = false, parentCommentId = null) => {
+    try {
+      await handleCommentEdit(commentId, content, isReply, parentCommentId);
+    } catch (err) {
+      alert(err.message);
+      throw err;
+    }
+  };
 
-  const topLevelComments = comments.filter((c) => c.parentCommentId == null);
-  const sortedComments = topLevelComments
-    .slice()
-    .sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
-  const visibleComments = sortedComments.slice(0, commentsToShow);
+  /**
+   * 댓글 삭제 처리
+   */
+  const handleCommentDeleteWrapper = async (commentId, isReply = false, parentCommentId = null) => {
+    try {
+      await handleCommentDelete(commentId, isReply, parentCommentId);
+    } catch (err) {
+      alert(err.message);
+      throw err;
+    }
+  };
+
+  /**
+   * 대댓글 로드 처리
+   */
+  const handleLoadReplies = (commentId) => {
+    loadReplies(commentId);
+  };
+
+  /**
+   * 더 많은 댓글 로드
+   */
+  const handleLoadMore = () => {
+    if (!loading && hasNext) {
+      loadMoreComments();
+    }
+  };
+
+  if (error) {
+    return (
+        <div className="community-detail-comments">
+          <div className="alert alert-danger" role="alert">
+            {error}
+            <button
+                className="btn btn-outline-danger btn-sm ms-2"
+                onClick={() => window.location.reload()}
+            >
+              새로고침
+            </button>
+          </div>
+        </div>
+    );
+  }
 
   return (
-    <div className="community-detail-comments">
-      <form className="community-detail-comment-form" onSubmit={handleAdd}>
-        <input
-          type="text"
-          value={value}
-          onChange={onChange}
-          placeholder="댓글을 작성해주세요"
-        />
-        <button type="submit">댓글 쓰기</button>
-      </form>
-      <div className="community-detail-comment-list">
-        {visibleComments.map((c) => (
-          <CommentItem
-            key={c.id}
-            comment={c}
-            user={user}
-            onReplyAdd={handleReplyAdd}
-            onEdit={handleCommentEdit}
-            onDelete={handleCommentDelete}
-            depth={1}
-            allComments={comments}
-          />
-        ))}
-        {commentsToShow < topLevelComments.length && (
-          <div ref={loaderRef} style={{ height: 32 }} />
-        )}
+      <div className="community-detail-comments">
+        {/* 댓글 작성 폼 */}
+        <form className="community-detail-comment-form" onSubmit={handleAdd}>
+          <div className="d-flex gap-2">
+            <input
+                type="text"
+                className="form-control"
+                value={value}
+                onChange={onChange}
+                placeholder="댓글을 작성해주세요"
+                disabled={submitLoading}
+            />
+            <button
+                type="submit"
+                className="btn btn-primary"
+                disabled={submitLoading || !value.trim()}
+            >
+              {submitLoading ? '작성 중...' : '댓글 쓰기'}
+            </button>
+          </div>
+        </form>
+
+        {/* 댓글 목록 */}
+        <div className="community-detail-comment-list">
+          {!initialLoaded ? (
+              // 초기 로딩 중
+              <div className="text-center py-4">
+                <div className="spinner-border" role="status">
+                  <span className="visually-hidden">댓글을 불러오는 중...</span>
+                </div>
+              </div>
+          ) : comments.length === 0 ? (
+              // 댓글이 없음
+              <div className="text-center py-4 text-muted">
+                아직 댓글이 없습니다. 첫 번째 댓글을 작성해보세요!
+              </div>
+          ) : (
+              // 댓글 목록 표시
+              <>
+                {comments.map((comment) => (
+                    <CommentItem
+                        key={comment.id}
+                        comment={comment}
+                        user={user}
+                        postId={postId}
+                        onReplyAdd={handleReplyAddWrapper}
+                        onEdit={handleCommentEditWrapper}
+                        onDelete={handleCommentDeleteWrapper}
+                        onLoadReplies={handleLoadReplies}
+                        onLoadMoreReplies={loadMoreReplies}
+                        repliesData={repliesData[comment.id]}
+                        repliesLoading={repliesLoading[comment.id]}
+                        depth={1}
+                        allComments={comments} // 기존 호환성을 위해 유지
+                    />
+                ))}
+
+                {/* 더 보기 버튼 */}
+                {hasNext && (
+                    <div className="text-center py-4">
+                      <button
+                          className="btn-load-more"
+                          onClick={handleLoadMore}
+                          disabled={loading}
+                      >
+                        {loading ? (
+                            <div className="load-more-loading">
+                              <div className="spinner"></div>
+                              <span>댓글을 불러오는 중...</span>
+                            </div>
+                        ) : (
+                            <div className="load-more-content">
+                              <svg className="load-more-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                              </svg>
+                              <span>더 많은 댓글 보기</span>
+                              <div className="load-more-ripple"></div>
+                            </div>
+                        )}
+                      </button>
+                    </div>
+                )}
+
+                {/* 모든 댓글을 다 불러온 경우 */}
+                {!hasNext && comments.length > 0 && (
+                    <div className="text-center py-3 text-muted">
+                      <small>모든 댓글을 불러왔습니다</small>
+                    </div>
+                )}
+              </>
+          )}
+        </div>
       </div>
-    </div>
   );
 };
 

--- a/src/hooks/useComments.js
+++ b/src/hooks/useComments.js
@@ -22,7 +22,6 @@ export const useComments = (postId, initialSize = 10) => {
   const loadComments = useCallback(async (cursor = null, size = initialSize) => {
     // 중복 로딩 방지
     if (loadingRef.current) {
-      console.log('이미 로딩 중이므로 요청 무시');
       return;
     }
 
@@ -32,8 +31,6 @@ export const useComments = (postId, initialSize = 10) => {
 
     try {
       const response = await commentApi.getComments(postId, cursor, size);
-      console.log(response)
-
       if (cursor) {
         // 추가 로드
         setComments(prev => [...prev, ...response.comments]);
@@ -50,7 +47,6 @@ export const useComments = (postId, initialSize = 10) => {
       setError(err.message || '댓글을 불러오는 중 오류가 발생했습니다.');
       setInitialLoaded(true);
       initialLoadRef.current = true;
-      console.error('댓글 로드 실패:', err);
     } finally {
       setLoading(false);
       loadingRef.current = false;
@@ -91,7 +87,6 @@ export const useComments = (postId, initialSize = 10) => {
         };
       });
     } catch (err) {
-      console.error('대댓글 로드 실패:', err);
     } finally {
       setRepliesLoading(prev => ({ ...prev, [commentId]: false }));
     }
@@ -124,7 +119,6 @@ export const useComments = (postId, initialSize = 10) => {
 
       return newComment;
     } catch (err) {
-      console.error('댓글 작성 실패:', err);
       throw new Error(err.message || '댓글 작성 중 오류가 발생했습니다.');
     }
   }, [postId, hasNext]);
@@ -165,7 +159,6 @@ export const useComments = (postId, initialSize = 10) => {
 
       return newReply;
     } catch (err) {
-      console.error('대댓글 작성 실패:', err);
       throw new Error(err.message || '대댓글 작성 중 오류가 발생했습니다.');
     }
   }, [postId, repliesData]);
@@ -199,7 +192,6 @@ export const useComments = (postId, initialSize = 10) => {
         ));
       }
     } catch (err) {
-      console.error('댓글 수정 실패:', err);
       throw new Error(err.message || '댓글 수정 중 오류가 발생했습니다.');
     }
   }, [postId]);
@@ -235,7 +227,6 @@ export const useComments = (postId, initialSize = 10) => {
         });
       }
     } catch (err) {
-      console.error('댓글 삭제 실패:', err);
       throw new Error(err.message || '댓글 삭제 중 오류가 발생했습니다.');
     }
   }, [postId]);
@@ -258,7 +249,6 @@ export const useComments = (postId, initialSize = 10) => {
    */
   useEffect(() => {
     if (postId && !initialLoadRef.current) {
-      console.log('초기 댓글 로드 시작:', postId);
       loadComments();
     }
   }, [postId]); // loadComments 의존성 제거

--- a/src/hooks/useComments.js
+++ b/src/hooks/useComments.js
@@ -1,56 +1,302 @@
-import { useState } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
+import { commentApi } from "../services/commentApi";
 import { useAuth } from "../context/AuthContext";
 
-function createCommentObject(content, user, postId, parentCommentId = null) {
-  return {
-    id: Date.now() + Math.random(), // 임시 ID
-    postId,
-    nickname: user?.nickname || "익명",
-    profileImageUrl: user?.image_url || "https://via.placeholder.com/40",
-    parentCommentId,
-    content,
-    replyCount: 0,
-    likeCount: 0,
-    hasLiked: false,
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
-  };
-}
+export const useComments = (postId, initialSize = 10) => {
+  const [comments, setComments] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [initialLoaded, setInitialLoaded] = useState(false);
+  const [error, setError] = useState(null);
+  const [nextCursor, setNextCursor] = useState(null);
+  const [hasNext, setHasNext] = useState(false);
+  const [repliesData, setRepliesData] = useState({});
+  const [repliesLoading, setRepliesLoading] = useState({});
 
-export const useComments = (initialComments = [], postId) => {
-  const [comments, setComments] = useState(initialComments);
   const { user } = useAuth();
+  const loadingRef = useRef(false); // 중복 로딩 방지용 ref
+  const initialLoadRef = useRef(false); // 초기 로딩 완료 추적용 ref
 
-  const handleCommentAdd = (content) => {
-    const newComment = createCommentObject(content, user, postId);
-    setComments((prev) => [newComment, ...prev]);
-  };
+  /**
+   * 댓글 목록 조회
+   */
+  const loadComments = useCallback(async (cursor = null, size = initialSize) => {
+    // 중복 로딩 방지
+    if (loadingRef.current) {
+      console.log('이미 로딩 중이므로 요청 무시');
+      return;
+    }
 
-  const handleReplyAdd = (parentId, content) => {
-    const newReply = createCommentObject(content, user, postId, parentId);
-    setComments((prev) => [...prev, newReply]);
-  };
+    loadingRef.current = true;
+    setLoading(true);
+    setError(null);
 
-  const handleCommentEdit = (commentId, content) => {
-    setComments((prev) =>
-      prev.map((comment) =>
-        comment.id === commentId
-          ? { ...comment, content, updatedAt: new Date().toISOString() }
-          : comment
-      )
-    );
-  };
+    try {
+      const response = await commentApi.getComments(postId, cursor, size);
+      console.log(response)
 
-  const handleCommentDelete = (commentId) => {
-    setComments((prev) => prev.filter((c) => c.id !== commentId));
-  };
+      if (cursor) {
+        // 추가 로드
+        setComments(prev => [...prev, ...response.comments]);
+      } else {
+        // 초기 로드
+        setComments(response.comments);
+        setInitialLoaded(true);
+        initialLoadRef.current = true;
+      }
+
+      setNextCursor(response.nextCursor);
+      setHasNext(response.hasNext);
+    } catch (err) {
+      setError(err.message || '댓글을 불러오는 중 오류가 발생했습니다.');
+      setInitialLoaded(true);
+      initialLoadRef.current = true;
+      console.error('댓글 로드 실패:', err);
+    } finally {
+      setLoading(false);
+      loadingRef.current = false;
+    }
+  }, [postId, initialSize]);
+
+  /**
+   * 더 많은 댓글 로드
+   */
+  const loadMoreComments = useCallback(() => {
+    if (hasNext && nextCursor && !loadingRef.current) {
+      loadComments(nextCursor, initialSize);
+    }
+  }, [hasNext, nextCursor, loadComments]);
+
+  /**
+   * 대댓글 로드
+   */
+  const loadReplies = useCallback(async (commentId, cursor = null, size = 5) => {
+    if (repliesLoading[commentId]) return;
+
+    setRepliesLoading(prev => ({ ...prev, [commentId]: true }));
+
+    try {
+      const response = await commentApi.getReplies(postId, commentId, cursor, size);
+
+      setRepliesData(prev => {
+        const existingReplies = prev[commentId]?.comments || [];
+        const newReplies = cursor ? [...existingReplies, ...response.comments] : response.comments;
+
+        return {
+          ...prev,
+          [commentId]: {
+            comments: newReplies,
+            nextCursor: response.nextCursor,
+            hasNext: response.hasNext
+          }
+        };
+      });
+    } catch (err) {
+      console.error('대댓글 로드 실패:', err);
+    } finally {
+      setRepliesLoading(prev => ({ ...prev, [commentId]: false }));
+    }
+  }, [postId]);
+
+  /**
+   * 더 많은 대댓글 로드
+   */
+  const loadMoreReplies = useCallback((commentId) => {
+    const replyData = repliesData[commentId];
+    if (replyData?.hasNext && replyData?.nextCursor && !repliesLoading[commentId]) {
+      loadReplies(commentId, replyData.nextCursor, 5);
+    }
+  }, [repliesData, repliesLoading, loadReplies]);
+
+  /**
+   * 댓글 작성
+   */
+  const handleCommentAdd = useCallback(async (content) => {
+    if (!content.trim()) return;
+
+    try {
+      const newComment = await commentApi.createComment(postId, { content });
+
+      // 더보기가 모두 완료된 상태(!hasNext)인 경우에만 UI에 바로 추가
+      if (!hasNext) {
+        setComments(prev => [...prev, newComment]); // 맨 아래 추가 (역순이므로)
+      }
+      // hasNext가 true면 새 댓글은 서버에서 다음 로드 시 나타남
+
+      return newComment;
+    } catch (err) {
+      console.error('댓글 작성 실패:', err);
+      throw new Error(err.message || '댓글 작성 중 오류가 발생했습니다.');
+    }
+  }, [postId, hasNext]);
+
+  /**
+   * 대댓글 작성
+   */
+  const handleReplyAdd = useCallback(async (parentCommentId, content) => {
+    if (!content.trim()) return;
+
+    try {
+      const newReply = await commentApi.createComment(postId, {
+        content,
+        parentCommentId
+      });
+
+      // 해당 댓글의 대댓글이 모두 로드된 상태에서만 UI에 바로 추가
+      const parentRepliesData = repliesData[parentCommentId];
+      if (parentRepliesData && !parentRepliesData.hasNext) {
+        setRepliesData(prev => {
+          const existingData = prev[parentCommentId] || { comments: [], hasNext: false, nextCursor: null };
+          return {
+            ...prev,
+            [parentCommentId]: {
+              ...existingData,
+              comments: [...existingData.comments, newReply] // 맨 아래 추가
+            }
+          };
+        });
+      }
+
+      // 부모 댓글의 replyCount는 항상 증가
+      setComments(prev => prev.map(comment =>
+          comment.id === parentCommentId
+              ? { ...comment, replyCount: (comment.replyCount || 0) + 1 }
+              : comment
+      ));
+
+      return newReply;
+    } catch (err) {
+      console.error('대댓글 작성 실패:', err);
+      throw new Error(err.message || '대댓글 작성 중 오류가 발생했습니다.');
+    }
+  }, [postId, repliesData]);
+
+  /**
+   * 댓글 수정
+   */
+  const handleCommentEdit = useCallback(async (commentId, content, isReply = false, parentCommentId = null) => {
+    if (!content.trim()) return;
+
+    try {
+      await commentApi.updateComment(postId, commentId, { content });
+
+      if (isReply && parentCommentId) {
+        setRepliesData(prev => ({
+          ...prev,
+          [parentCommentId]: {
+            ...prev[parentCommentId],
+            comments: prev[parentCommentId].comments.map(reply =>
+                reply.id === commentId
+                    ? { ...reply, content, updatedAt: new Date().toISOString() }
+                    : reply
+            )
+          }
+        }));
+      } else {
+        setComments(prev => prev.map(comment =>
+            comment.id === commentId
+                ? { ...comment, content, updatedAt: new Date().toISOString() }
+                : comment
+        ));
+      }
+    } catch (err) {
+      console.error('댓글 수정 실패:', err);
+      throw new Error(err.message || '댓글 수정 중 오류가 발생했습니다.');
+    }
+  }, [postId]);
+
+  /**
+   * 댓글 삭제
+   */
+  const handleCommentDelete = useCallback(async (commentId, isReply = false, parentCommentId = null) => {
+    try {
+      await commentApi.deleteComment(postId, commentId);
+
+      if (isReply && parentCommentId) {
+        setRepliesData(prev => ({
+          ...prev,
+          [parentCommentId]: {
+            ...prev[parentCommentId],
+            comments: prev[parentCommentId].comments.filter(reply => reply.id !== commentId)
+          }
+        }));
+
+        setComments(prev => prev.map(comment =>
+            comment.id === parentCommentId
+                ? { ...comment, replyCount: Math.max((comment.replyCount || 0) - 1, 0) }
+                : comment
+        ));
+      } else {
+        setComments(prev => prev.filter(comment => comment.id !== commentId));
+
+        setRepliesData(prev => {
+          const newData = { ...prev };
+          delete newData[commentId];
+          return newData;
+        });
+      }
+    } catch (err) {
+      console.error('댓글 삭제 실패:', err);
+      throw new Error(err.message || '댓글 삭제 중 오류가 발생했습니다.');
+    }
+  }, [postId]);
+
+  /**
+   * 댓글 새로고침
+   */
+  const refreshComments = useCallback(() => {
+    setComments([]);
+    setRepliesData({});
+    setNextCursor(null);
+    setHasNext(false);
+    setInitialLoaded(false);
+    initialLoadRef.current = false;
+    loadComments();
+  }, [loadComments]);
+
+  /**
+   * 초기 데이터 로드 - postId가 변경될 때만 실행
+   */
+  useEffect(() => {
+    if (postId && !initialLoadRef.current) {
+      console.log('초기 댓글 로드 시작:', postId);
+      loadComments();
+    }
+  }, [postId]); // loadComments 의존성 제거
+
+  /**
+   * postId가 변경되면 상태 초기화
+   */
+  useEffect(() => {
+    setComments([]);
+    setRepliesData({});
+    setNextCursor(null);
+    setHasNext(false);
+    setInitialLoaded(false);
+    setError(null);
+    initialLoadRef.current = false;
+    loadingRef.current = false;
+  }, [postId]);
 
   return {
+    // 상태
     comments,
     setComments,
+    loading,
+    initialLoaded,
+    error,
+    hasNext,
+    repliesData,
+    repliesLoading,
+
+    // 함수들
     handleCommentAdd,
     handleReplyAdd,
     handleCommentEdit,
     handleCommentDelete,
+    loadComments,
+    loadMoreComments,
+    loadReplies,
+    loadMoreReplies,
+    refreshComments,
   };
 };

--- a/src/pages/community/CommunityPage.jsx
+++ b/src/pages/community/CommunityPage.jsx
@@ -80,26 +80,28 @@ export default function CommunityPage() {
                 onSearch={search} // 검색 버튼 클릭 시
             />
 
-            {/* 로딩 상태 표시 */}
-            {loading && (
-                <div className="text-center py-3">
+            {/* 로딩 상태일 때는 기존 컨텐츠 숨기고 로딩만 표시 */}
+            {loading ? (
+                <div className="text-center py-5">
                   <Spinner animation="border" size="sm" className="me-2" />
                   게시글을 불러오는 중...
                 </div>
+            ) : (
+                <>
+                  <CommunityBoardList posts={posts} onPostClick={handlePostClick} />
+
+                  {/* 게시글이 없을 때 메시지 */}
+                  {posts.length === 0 && (
+                      <div className="text-center py-5">
+                        <p className="text-muted">
+                          {keyword ? `"${keyword}"에 대한 검색 결과가 없습니다.` : "등록된 게시글이 없습니다."}
+                        </p>
+                      </div>
+                  )}
+
+                  <BoardPagination page={page} total={totalPages} onChange={setPage} />
+                </>
             )}
-
-            <CommunityBoardList posts={posts} onPostClick={handlePostClick} />
-
-            {/* 게시글이 없을 때 메시지 */}
-            {!loading && posts.length === 0 && (
-                <div className="text-center py-5">
-                  <p className="text-muted">
-                    {keyword ? `"${keyword}"에 대한 검색 결과가 없습니다.` : "등록된 게시글이 없습니다."}
-                  </p>
-                </div>
-            )}
-
-            <BoardPagination page={page} total={totalPages} onChange={setPage} />
           </div>
         </div>
       </>

--- a/src/services/commentApi.js
+++ b/src/services/commentApi.js
@@ -17,7 +17,6 @@ export const commentApi = {
             const response = await apiClient.get(`/api/v1/posts/${postId}/comments?${params}`);
             return response.data;
         } catch (error) {
-            console.error('댓글 목록 조회 실패:', error);
             throw error;
         }
     },
@@ -35,7 +34,6 @@ export const commentApi = {
             const response = await apiClient.get(`/api/v1/posts/${postId}/comments/${commentId}/replies?${params}`);
             return response.data;
         } catch (error) {
-            console.error('대댓글 목록 조회 실패:', error);
             throw error;
         }
     },
@@ -48,7 +46,6 @@ export const commentApi = {
             const response = await apiClient.post(`/api/v1/posts/${postId}/comments`, commentData);
             return response.data;
         } catch (error) {
-            console.error('댓글 작성 실패:', error);
             throw error;
         }
     },
@@ -61,7 +58,6 @@ export const commentApi = {
             const response = await apiClient.put(`/api/v1/posts/${postId}/comments/${commentId}`, commentData);
             return response.data;
         } catch (error) {
-            console.error('댓글 수정 실패:', error);
             throw error;
         }
     },
@@ -74,7 +70,6 @@ export const commentApi = {
             const response = await apiClient.delete(`/api/v1/posts/${postId}/comments/${commentId}`);
             return response.data;
         } catch (error) {
-            console.error('댓글 삭제 실패:', error);
             throw error;
         }
     }

--- a/src/services/commentApi.js
+++ b/src/services/commentApi.js
@@ -1,0 +1,81 @@
+import { apiClient } from './api.js';
+
+/**
+ * 댓글 API 서비스
+ */
+export const commentApi = {
+    /**
+     * 댓글 목록 조회 (부모 댓글만, 커서 기반 페이지네이션)
+     */
+    getComments: async (postId, cursor = null, size = 10) => {
+        try {
+            const params = new URLSearchParams({ size: size.toString() });
+            if (cursor) {
+                params.append('cursor', cursor.toString());
+            }
+
+            const response = await apiClient.get(`/api/v1/posts/${postId}/comments?${params}`);
+            return response.data;
+        } catch (error) {
+            console.error('댓글 목록 조회 실패:', error);
+            throw error;
+        }
+    },
+
+    /**
+     * 대댓글 목록 조회
+     */
+    getReplies: async (postId, commentId, cursor = null, size = 5) => {
+        try {
+            const params = new URLSearchParams({ size: size.toString() });
+            if (cursor) {
+                params.append('cursor', cursor.toString());
+            }
+
+            const response = await apiClient.get(`/api/v1/posts/${postId}/comments/${commentId}/replies?${params}`);
+            return response.data;
+        } catch (error) {
+            console.error('대댓글 목록 조회 실패:', error);
+            throw error;
+        }
+    },
+
+    /**
+     * 댓글 작성
+     */
+    createComment: async (postId, commentData) => {
+        try {
+            const response = await apiClient.post(`/api/v1/posts/${postId}/comments`, commentData);
+            return response.data;
+        } catch (error) {
+            console.error('댓글 작성 실패:', error);
+            throw error;
+        }
+    },
+
+    /**
+     * 댓글 수정
+     */
+    updateComment: async (postId, commentId, commentData) => {
+        try {
+            const response = await apiClient.put(`/api/v1/posts/${postId}/comments/${commentId}`, commentData);
+            return response.data;
+        } catch (error) {
+            console.error('댓글 수정 실패:', error);
+            throw error;
+        }
+    },
+
+    /**
+     * 댓글 삭제
+     */
+    deleteComment: async (postId, commentId) => {
+        try {
+            const response = await apiClient.delete(`/api/v1/posts/${postId}/comments/${commentId}`);
+            return response.data;
+        } catch (error) {
+            console.error('댓글 삭제 실패:', error);
+            throw error;
+        }
+    }
+};

--- a/src/styles/components/comment/CommentSection.css
+++ b/src/styles/components/comment/CommentSection.css
@@ -1,0 +1,193 @@
+/* 미니멀한 더보기 버튼 스타일 */
+.btn-load-more {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 12px 28px;
+    background: #ffffff;
+    border: 2px solid #e5e7eb;
+    border-radius: 12px;
+    color: #374151;
+    font-size: 15px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    min-width: 180px;
+    gap: 8px;
+}
+
+.btn-load-more:hover:not(:disabled) {
+    border-color: #3b82f6;
+    color: #3b82f6;
+    background: #f8fafc;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(59, 130, 246, 0.15);
+}
+
+.btn-load-more:active:not(:disabled) {
+    transform: translateY(0);
+    box-shadow: 0 2px 4px rgba(59, 130, 246, 0.1);
+}
+
+.btn-load-more:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+    transform: none;
+}
+
+/* 대댓글 더보기 버튼 (작은 버전) */
+.btn-load-more-replies {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px 20px;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    color: #64748b;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    min-width: 140px;
+    gap: 6px;
+}
+
+.btn-load-more-replies:hover:not(:disabled) {
+    border-color: #3b82f6;
+    color: #3b82f6;
+    background: #ffffff;
+    transform: translateY(-1px);
+    box-shadow: 0 2px 8px rgba(59, 130, 246, 0.1);
+}
+
+.btn-load-more-replies:active:not(:disabled) {
+    transform: translateY(0);
+    box-shadow: 0 1px 3px rgba(59, 130, 246, 0.1);
+}
+
+.btn-load-more-replies:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+    transform: none;
+}
+
+/* 아이콘 */
+.load-more-icon {
+    width: 18px;
+    height: 18px;
+    transition: transform 0.2s ease;
+}
+
+.load-more-icon-small {
+    width: 14px;
+    height: 14px;
+    transition: transform 0.2s ease;
+}
+
+.btn-load-more:hover .load-more-icon,
+.btn-load-more-replies:hover .load-more-icon-small {
+    transform: translateY(1px);
+}
+
+/* 로딩 상태 */
+.load-more-loading {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.load-more-loading-small {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.spinner {
+    width: 16px;
+    height: 16px;
+    border: 2px solid #e5e7eb;
+    border-top: 2px solid #3b82f6;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+.spinner-small {
+    width: 14px;
+    height: 14px;
+    border: 2px solid #e2e8f0;
+    border-top: 2px solid #3b82f6;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+.load-more-content {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.load-more-content-small {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+/* 다크 모드 */
+@media (prefers-color-scheme: dark) {
+    .btn-load-more {
+        background: #1f2937;
+        border-color: #374151;
+        color: #d1d5db;
+    }
+
+    .btn-load-more:hover:not(:disabled) {
+        border-color: #60a5fa;
+        color: #60a5fa;
+        background: #111827;
+    }
+
+    .btn-load-more-replies {
+        background: #374151;
+        border-color: #4b5563;
+        color: #9ca3af;
+    }
+
+    .btn-load-more-replies:hover:not(:disabled) {
+        border-color: #60a5fa;
+        color: #60a5fa;
+        background: #1f2937;
+    }
+
+    .spinner {
+        border-color: #374151;
+        border-top-color: #60a5fa;
+    }
+
+    .spinner-small {
+        border-color: #4b5563;
+        border-top-color: #60a5fa;
+    }
+}
+
+/* 반응형 */
+@media (max-width: 768px) {
+    .btn-load-more {
+        padding: 10px 20px;
+        font-size: 14px;
+        min-width: 160px;
+    }
+
+    .btn-load-more-replies {
+        padding: 6px 16px;
+        font-size: 12px;
+        min-width: 120px;
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
#42

## 📝작업 내용

예시 댓글)
![image](https://github.com/user-attachments/assets/5d6b8b34-fdae-4a07-8e3a-e05222f2e2fa)

<hr>

![image](https://github.com/user-attachments/assets/25051117-7be9-47c2-bbea-22a824c4a5c5)

UI는 나중에 수정이 필요할 듯 보입니다.
현재 아직 댓글 작성자와 유저가 검증하는 로직이 없어 삭제 수정 버튼 처리가 아직 안되어있습니다

### 🚀 주요 구현 기능
- **댓글 시스템 백엔드 API 연동 완료**
  - 댓글 CRUD (작성, 조회, 수정, 삭제) 기능
  - 대댓글 CRUD 기능 
  - 페이지네이션 기반 댓글 로딩 (더보기 방식)

### 🔧 구현한 컴포넌트 및 훅
- **CommentSection**: 댓글 전체 관리 컴포넌트
- **CommentItem**: 개별 댓글 아이템 컴포넌트  
- **useComments**: 댓글 관련 상태 및 API 호출 관리 훅
- **commentApi**: 댓글 관련 API 서비스

### ⚡ 주요 기능 상세
- **더보기 버튼 방식**: 페이지네이션으로 댓글을 점진적 로드
- **대댓글 토글**: 답글 보기/숨기기 기능


## 💬리뷰 요구사항(선택) 및 기타 참고사항
- **API 연동**: 백엔드 API와의 연동이 정상적으로 동작하는지 확인 필요
- **성능**: 많은 댓글이 있을 때 페이지네이션이 원활히 작동하는지 테스트 필요
- **UX**: 댓글 작성/수정 시 사용자 경험이 자연스러운지 검토 필요
- **권한**: 댓글 수정/삭제 권한이 올바르게 적용되는지 확인
- **에러 처리**: 네트워크 오류 등 예외 상황 처리 로직 검토

## ✅ 체크리스트
- [x] 코드 점검 완료했습니다
- [x] 문서/주석 최신화 완료했습니다
