### PR TITLE
Feat: 함께해요 게시글 수정, 삭제

### DIFF
--- a/src/components/board/BoardPostHeader.jsx
+++ b/src/components/board/BoardPostHeader.jsx
@@ -28,20 +28,17 @@ export const BoardPostHeader = ({
     isDeleting
 }) => {
   const { user: currentUser } = useAuth();
-    const canEditOrDelete = currentUser && isAuthorByNickname(currentUser.nickname, post.user.nickname);
 
-  const user =
-    post.user ||
-    (post.nickname && post.profileImageUrl
-      ? {
+  const user = post.user ||
+    (post.nickname ? {
           nickname: post.nickname,
           profileImageUrl: post.profileImageUrl,
           devcourseName: post.devcourseName,
           devcourseBatch: post.devcourseBatch,
         }
       : null);
-
-  const status = post.gathering_post?.status || post.market_item?.status;
+    const canEditOrDelete = currentUser && isAuthorByNickname(currentUser.nickname, user?.nickname);
+    const status = post.gathering_post?.status || post.market_item?.status;
 
   const getStatusBadgeClass = () => {
     if (!status) return "d-none";

--- a/src/components/together/TogetherBoardDetail.jsx
+++ b/src/components/together/TogetherBoardDetail.jsx
@@ -3,6 +3,9 @@ import { useNavigate } from "react-router-dom";
 import { PostContent } from "../common/PostContent";
 import TogetherPostInfo from "./TogetherPostInfo";
 import { BoardDetailLayout } from "../board/BoardDetailLayout";
+import { deleteGatheringPost } from "../../services/together/gatheringApi";
+import { deleteMatchingPost } from "../../services/together/matchingApi";
+import { deleteMarketPost } from "../../services/together/marketApi";
 
 /**
  * @typedef {Object} TogetherBoardDetailProps
@@ -24,12 +27,13 @@ const TogetherBoardDetail = ({ post, onLike, onBookmark, boardType }) => {
     });
   };
 
-  const handleDelete = () => {
-    if (window.confirm("정말로 이 게시글을 삭제하시겠습니까?")) {
-      console.log("삭제할 게시글 ID:", post.postId);
-      alert("게시글이 삭제되었습니다.");
-      navigate(`/together/${boardType}`);
-    }
+  const handleDelete = async () => {
+    if (!window.confirm("정말 삭제하시겠습니까?")) return;
+    if (boardType === "GATHERING")      await deleteGatheringPost(post.id);
+    else if (boardType === "MATCH")     await deleteMatchingPost(post.id);
+    else /* MARKET */                   await deleteMarketPost(post.id);
+    alert("삭제되었습니다.");
+    navigate(`/together/${boardType}`);
   };
 
   if (!post) {

--- a/src/components/together/TogetherBoardDetail.jsx
+++ b/src/components/together/TogetherBoardDetail.jsx
@@ -22,7 +22,7 @@ const TogetherBoardDetail = ({ post, onLike, onBookmark, boardType }) => {
   const navigate = useNavigate();
 
   const handleEdit = () => {
-    navigate(`/together/${boardType.toLowerCase()}/write`, {
+    navigate(`/together/${boardType.toLowerCase()}/write/${post.id}`, {
       state: { postToEdit: post },
     });
   };

--- a/src/pages/together/TogetherWritePage.jsx
+++ b/src/pages/together/TogetherWritePage.jsx
@@ -40,9 +40,9 @@ function TogetherWritePage() {
     (async () => {
       try {
         let data;
-        if (boardType === "GATHERING") {
+        if (boardType === "gathering") {
           data = await getGatheringPostDetail(postId);
-        } else if (boardType === "MATCH") {
+        } else if (boardType === "match") {
           data = await getMatchingPostDetail(postId);
         } else {
           data = await getMarketPostDetail(postId);

--- a/src/router/Router.jsx
+++ b/src/router/Router.jsx
@@ -58,6 +58,7 @@ export function AppRouter() {
             <Route path="/together/:boardType" element={<ProtectedRoute><TogetherPage /></ProtectedRoute>} />
             <Route path="/together/:boardType/:postId" element={<ProtectedRoute><TogetherBoardDetailPage /></ProtectedRoute>} />
             <Route path="/together/:boardType/write" element={<ProtectedRoute><TogetherWritePage /></ProtectedRoute>} />
+            <Route path="/together/:boardType/write/:postId" element={<ProtectedRoute><TogetherWritePage /></ProtectedRoute>} />
             <Route path="/info" element={<Navigate to="/info/review" replace />} />
             <Route path="/info/:boardType" element={<InfoPage />} />
             <Route path="/info/:boardType/:itId" element={<InfoBoardDetailPage />} />


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호 (작성 시 지우기)

#80 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) - (작성 시 지우기)

함께해요 게시판 글 본인 작성 여부에 따른 수정 삭제 기능

## 💬리뷰 요구사항(선택) 및 기타 참고사항

> ex) 실행 시 yml 파일 필요합니다. (작성 시 지우기)

수정 시 카테고리 및 세부유형이 자동선택이 되어 원래 내용이 나와야 하는데 직접 눌러야 내용들이 나옴 -> 수정필요

사용자 삭제 시 해당 사용자와 관련된 데이터(게시글, 댓글 등)가 그대로 남아있는 것 같아요.

댓글은 내가 작성한 것이 아님에도 수정/삭제 버튼이 보이는 버그가 발견

## ✅ 체크리스트

- [ ] 코드 점검 완료했습니다
- [ ] 문서/주석 최신화 완료했습니다
