### PR TITLE
Feat : 비밀번호 재설정 연동 #123

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ function AppContent() {
     "/signup",
     "/signup/profile",
     "/find-account",
+    "/reset-password", 
   ];
 
   return (

--- a/src/components/auth/FindPasswordForm.jsx
+++ b/src/components/auth/FindPasswordForm.jsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useState } from "react";
+import { requestPasswordReset } from "../../services/api";
 import "../../styles/components/auth/auth.css";
 import { useInput } from "../../hooks/useInput";
 
@@ -7,12 +8,23 @@ import { useInput } from "../../hooks/useInput";
  */
 export const FindPasswordForm = () => {
   const { value: email, onChange: onEmailChange } = useInput("");
-  const [sent, setSent] = React.useState(false);
+  const [sent, setSent] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    // TODO: 실제 이메일 전송 로직
-    setSent(true);
+    setLoading(true);
+    setError("");
+
+    try {
+      await requestPasswordReset(email);
+      setSent(true);
+    } catch (err) {
+      setError(err.response?.data?.message || "이메일 전송에 실패했습니다.");
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -25,6 +37,13 @@ export const FindPasswordForm = () => {
           비밀번호 재설정 링크를 보내드립니다.
         </div>
       </div>
+      
+      {error && (
+        <div style={{ color: "red", marginBottom: "16px", textAlign: "center" }}>
+          {error}
+        </div>
+      )}
+
       {!sent ? (
         <form
           className="loginpage-figma-form signup-form"
@@ -38,13 +57,15 @@ export const FindPasswordForm = () => {
               value={email}
               onChange={onEmailChange}
               required
+              disabled={loading}
             />
           </div>
           <button
             type="submit"
             className="loginpage-figma-login-btn signup-btn"
+            disabled={loading}
           >
-            비밀번호 재설정 메일 받기
+            {loading ? "전송 중..." : "비밀번호 재설정 메일 받기"}
           </button>
         </form>
       ) : (

--- a/src/components/auth/FindPasswordForm.jsx
+++ b/src/components/auth/FindPasswordForm.jsx
@@ -39,7 +39,7 @@ export const FindPasswordForm = () => {
       </div>
       
       {error && (
-        <div style={{ color: "red", marginBottom: "16px", textAlign: "center" }}>
+        <div className="error-message">
           {error}
         </div>
       )}

--- a/src/components/auth/FindPasswordForm.jsx
+++ b/src/components/auth/FindPasswordForm.jsx
@@ -62,10 +62,15 @@ export const FindPasswordForm = () => {
           </div>
           <button
             type="submit"
-            className="loginpage-figma-login-btn signup-btn"
+            className="loginpage-figma-login-btn signup-btn d-flex align-items-center justify-content-center"
             disabled={loading}
           >
-            {loading ? "전송 중..." : "비밀번호 재설정 메일 받기"}
+            {loading && (
+              <div className="spinner-border spinner-border-sm me-2" role="status">
+                <span className="visually-hidden">Loading...</span>
+              </div>
+            )}
+            {loading ? "이메일 전송 중..." : "비밀번호 재설정 메일 받기"}
           </button>
         </form>
       ) : (

--- a/src/components/auth/ResetPasswordForm.jsx
+++ b/src/components/auth/ResetPasswordForm.jsx
@@ -1,0 +1,134 @@
+import React, { useState, useEffect } from "react";
+import { useSearchParams, useNavigate } from "react-router-dom";
+import { confirmPasswordReset } from "../../services/api";
+import { useInput } from "../../hooks/useInput";
+import "../../styles/components/auth/auth.css";
+
+/**
+ * 비밀번호 재설정 폼
+ */
+export const ResetPasswordForm = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const token = searchParams.get("token");
+
+  const { value: newPassword, onChange: onNewPasswordChange } = useInput("");
+  const { value: confirmPassword, onChange: onConfirmPasswordChange } = useInput("");
+  
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState(false);
+
+  useEffect(() => {
+    if (!token) {
+      setError("유효하지 않은 링크입니다.");
+    }
+  }, [token]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    
+    if (!token) {
+      setError("유효하지 않은 토큰입니다.");
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      setError("비밀번호가 일치하지 않습니다.");
+      return;
+    }
+
+    if (newPassword.length < 8) {
+      setError("비밀번호는 8자 이상이어야 합니다.");
+      return;
+    }
+
+    setLoading(true);
+    setError("");
+
+    try {
+      await confirmPasswordReset(token, newPassword, confirmPassword);
+      setSuccess(true);
+      
+      // 3초 후 로그인 페이지로 이동
+      setTimeout(() => {
+        navigate("/login");
+      }, 3000);
+    } catch (err) {
+      setError(err.response?.data?.message || "비밀번호 재설정에 실패했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (success) {
+    return (
+      <div className="loginpage-figma-card signup-figma-card">
+        <div className="signup-title-area">
+          <div className="signup-title">비밀번호 재설정 완료</div>
+          <div className="signup-desc">
+            비밀번호가 성공적으로 변경되었습니다.
+            <br />
+            잠시 후 로그인 페이지로 이동합니다.
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="loginpage-figma-card signup-figma-card">
+      <div className="signup-title-area">
+        <div className="signup-title">새 비밀번호 설정</div>
+        <div className="signup-desc">
+          새로운 비밀번호를 입력해 주세요.
+        </div>
+      </div>
+
+      {error && (
+        <div style={{ color: "red", marginBottom: "16px", textAlign: "center" }}>
+          {error}
+        </div>
+      )}
+
+      <form
+        className="loginpage-figma-form signup-form"
+        onSubmit={handleSubmit}
+      >
+        <div className="signup-label">새 비밀번호</div>
+        <div className="loginpage-figma-input-group">
+          <input
+            type="password"
+            placeholder="새 비밀번호를 입력해 주세요"
+            value={newPassword}
+            onChange={onNewPasswordChange}
+            required
+            disabled={loading}
+            minLength="8"
+          />
+        </div>
+
+        <div className="signup-label">새 비밀번호 확인</div>
+        <div className="loginpage-figma-input-group">
+          <input
+            type="password"
+            placeholder="새 비밀번호를 다시 입력해 주세요"
+            value={confirmPassword}
+            onChange={onConfirmPasswordChange}
+            required
+            disabled={loading}
+            minLength="8"
+          />
+        </div>
+
+        <button
+          type="submit"
+          className="loginpage-figma-login-btn signup-btn"
+          disabled={loading || !token}
+        >
+          {loading ? "변경 중..." : "비밀번호 변경"}
+        </button>
+      </form>
+    </div>
+  );
+};

--- a/src/pages/auth/ResetPasswordPage.jsx
+++ b/src/pages/auth/ResetPasswordPage.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { AuthLayout } from "../../components/auth/AuthLayout";
+import { ResetPasswordForm } from "../../components/auth/ResetPasswordForm";
+import "../../styles/components/auth/auth.css";
+
+const ResetPasswordPage = () => (
+  <AuthLayout>
+    <ResetPasswordForm />
+  </AuthLayout>
+);
+
+export default ResetPasswordPage;

--- a/src/router/Router.jsx
+++ b/src/router/Router.jsx
@@ -22,6 +22,7 @@ const HubWritePage = lazy(() => import("../pages/hub/HubWritePage"));
 const MyPage = lazy(() => import("../pages/mypage/MyPage"));
 const DMPage = lazy(() => import("../pages/dm/DMPage"));
 const OAuthCallbackPage = lazy(() => import("../pages/auth/OAuthCallbackPage"));
+const ResetPasswordPage = lazy(() => import("../pages/auth/ResetPasswordPage"));
 import { Spinner } from "react-bootstrap";
 
 const ProtectedRoute = ({ children }) => {
@@ -62,6 +63,7 @@ export function AppRouter() {
                 <Route path="/signup" element={<SignupPage />} />
                 <Route path="/signup/profile" element={<ProfileSetupPage />} />
                 <Route path="/find-account" element={<FindPasswordPage />} />
+                <Route path="/reset-password" element={<ResetPasswordPage />} /> 
 
                 <Route path="/community" element={<ProtectedRoute><Navigate to="/community/free" replace /></ProtectedRoute>} />
                 <Route path="/community/:boardType" element={<ProtectedRoute><CommunityPage /></ProtectedRoute>} />

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -36,7 +36,8 @@ const redirectToLogin = () => {
   if (
     currentPath === "/" ||
     currentPath === "/login" ||
-    currentPath === "/signup"
+    currentPath === "/signup" ||
+    currentPath.startsWith("/reset-password")
   ) {
     return;
   }
@@ -133,12 +134,12 @@ export const loginUser = async (credentials) => {
 
 // 비밀번호 재설정 요청
 export const requestPasswordReset = (email) => {
-  return apiClient.post('/auth/password/reset/request', { email });
+  return apiClient.post('/api/v1/auth/password/reset/request', { email });
 };
 
 // 비밀번호 재설정 확인
 export const confirmPasswordReset = (token, newPassword, confirmPassword) => {
-  return apiClient.post('/auth/password/reset/confirm', {
+  return apiClient.post('/api/v1/auth/password/reset/confirm', {
     token,
     newPassword,
     confirmPassword

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -130,3 +130,18 @@ export const loginUser = async (credentials) => {
     throw error;
   }
 };
+
+// 비밀번호 재설정 요청
+export const requestPasswordReset = (email) => {
+  return apiClient.post('/auth/password/reset/request', { email });
+};
+
+// 비밀번호 재설정 확인
+export const confirmPasswordReset = (token, newPassword, confirmPassword) => {
+  return apiClient.post('/auth/password/reset/confirm', {
+    token,
+    newPassword,
+    confirmPassword
+  });
+};
+


### PR DESCRIPTION
## #️⃣연관된 이슈

#123 

## 📝작업 내용

백엔드 비밀번호 재설정 API와 연동, 기능을 구현했습니다

- FindPasswordForm 개선: 실제 API 연동
- ResetPasswordPage 신규 생성: 토큰 기반 비밀번호 재설정
- ResetPasswordForm 컴포넌트: 새 비밀번호 입력 및 검증
- 라우팅 설정
- 에러 처리 통일: 기존 폼들과 동일한 스타일
- 유효성 검사: 기존 `isValidPassword`, `arePasswordsEqual` 유틸 활용
- UX 개선: 로딩 상태, 성공 메시지, 자동 리다이렉트

## 💬리뷰 요구사항(선택) 및 기타 참고사항

백엔드 ([BE #254](https://github.com/prgrms-aibe-devcourse/AIBE1-FinalProject-Team01-BE/pull/254)) 와 연동됩니다

## ✅ 체크리스트

- [ ] 코드 점검 완료했습니다
- [ ] 문서/주석 최신화 완료했습니다
