### PR TITLE
Feat: 팁탭 에디터 스크롤, 이미지 붙여넣기 기능 추가 #125

### DIFF
--- a/src/components/editor/CustomTiptapEditor.jsx
+++ b/src/components/editor/CustomTiptapEditor.jsx
@@ -30,6 +30,8 @@ export const CustomTiptapEditor = ({
   onChange,
   placeholder,
   onImageUpload, // 이미지 업로드 핸들러를 prop으로 받음
+  maxHeight = 800, // 전체 에디터 최대 높이
+  minHeight = 300, // 에디터 최소 높이
 }) => {
   const editor = useEditor({
     extensions: [
@@ -54,6 +56,9 @@ export const CustomTiptapEditor = ({
       onChange(editor.getHTML());
     },
     editorProps: {
+      attributes: {
+        style: `min-height: ${minHeight}px;`,
+      },
       handleDrop: function (view, event, slice, moved) {
         event.preventDefault();
 
@@ -108,9 +113,22 @@ export const CustomTiptapEditor = ({
   };
 
   return (
-    <div className="custom-editor border rounded">
-      <Toolbar editor={editor} handleImageUpload={handleToolbarImageUpload} />
-      <EditorContent editor={editor} />
+    <div 
+      className="custom-editor border rounded"
+      style={{ maxHeight: `${maxHeight}px` }}
+    >
+      <div className="toolbar-container">
+        <Toolbar editor={editor} handleImageUpload={handleToolbarImageUpload} />
+      </div>
+      <div 
+        className="editor-content"
+        style={{ 
+          maxHeight: `${maxHeight - 50}px`, // 툴바 높이 제외
+          minHeight: `${minHeight}px`
+        }}
+      >
+        <EditorContent editor={editor} />
+      </div>
     </div>
   );
 };

--- a/src/components/editor/CustomTiptapEditor.jsx
+++ b/src/components/editor/CustomTiptapEditor.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useEditor, EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import { createLowlight, all } from "lowlight";
@@ -25,6 +25,25 @@ const CustomCodeBlockLowlight = CodeBlockLowlight.extend({
   },
 });
 
+/**
+ * Tiptap 기반 커스텀 에디터 컴포넌트
+ * 
+ * 지원 기능:
+ * - 마크다운 문법 지원
+ * - 코드 블록 (구문 하이라이팅 포함)
+ * - 이미지 업로드 (드래그앤드롭, 파일 선택, 클립보드 붙여넣기)
+ * - 링크 자동 감지
+ * - Ctrl+Enter/Esc로 코드블록 탈출
+ * - Ctrl+V로 클립보드 이미지 붙여넣기
+ * 
+ * @param {Object} props
+ * @param {string} props.content - 에디터 초기 콘텐츠 (HTML)
+ * @param {Function} props.onChange - 콘텐츠 변경 시 콜백 함수
+ * @param {string} props.placeholder - 플레이스홀더 텍스트
+ * @param {Function} props.onImageUpload - 이미지 업로드 핸들러 함수
+ * @param {number} props.maxHeight - 에디터 최대 높이 (px)
+ * @param {number} props.minHeight - 에디터 최소 높이 (px)
+ */
 export const CustomTiptapEditor = ({
   content,
   onChange,
@@ -33,6 +52,7 @@ export const CustomTiptapEditor = ({
   maxHeight = 800, // 전체 에디터 최대 높이
   minHeight = 300, // 에디터 최소 높이
 }) => {
+  const [isUploading, setIsUploading] = useState(false);
   const editor = useEditor({
     extensions: [
       StarterKit.configure({
@@ -63,6 +83,7 @@ export const CustomTiptapEditor = ({
         event.preventDefault();
 
         if (onImageUpload && event.dataTransfer?.files?.length > 0) {
+          setIsUploading(true);
           onImageUpload(event.dataTransfer.files)
             .then((urls) => {
               if (urls && urls.length > 0 && editor) {
@@ -74,10 +95,52 @@ export const CustomTiptapEditor = ({
             .catch((error) => {
               console.error("Image upload on drop failed:", error);
               alert("이미지 업로드에 실패했습니다.");
+            })
+            .finally(() => {
+              setIsUploading(false);
             });
           return true;
         }
         return false;
+      },
+      handlePaste: function (view, event, slice) {
+        // 클립보드에서 이미지 데이터 확인
+        const items = Array.from(event.clipboardData?.items || []);
+        const imageItems = items.filter(item => item.type.startsWith('image/'));
+
+        if (imageItems.length > 0 && onImageUpload) {
+          event.preventDefault();
+          
+          // 클립보드의 이미지 데이터를 파일로 변환
+          const files = imageItems.map(item => item.getAsFile()).filter(Boolean);
+          
+          if (files.length > 0) {
+            // FileList로 변환 (useImageUpload과 호환)
+            const fileList = new DataTransfer();
+            files.forEach(file => fileList.items.add(file));
+            
+            setIsUploading(true);
+            onImageUpload(fileList.files)
+              .then((urls) => {
+                if (urls && urls.length > 0 && editor) {
+                  urls.forEach((url) => {
+                    editor.chain().focus().setImage({ src: url }).run();
+                  });
+                }
+              })
+              .catch((error) => {
+                console.error("Image upload on paste failed:", error);
+                alert("이미지 업로드에 실패했습니다.");
+              })
+              .finally(() => {
+                setIsUploading(false);
+              });
+          }
+          
+          return true; // 기본 paste 동작 방지
+        }
+        
+        return false; // 일반 텍스트 paste는 기본 동작 수행
       },
     },
   });
@@ -88,11 +151,72 @@ export const CustomTiptapEditor = ({
     }
   }, [content, editor]);
 
+  // 키보드 단축키를 통한 클립보드 이미지 붙여넣기
+  useEffect(() => {
+    const handleKeyDown = async (event) => {
+      // Ctrl+V (또는 Cmd+V) 감지
+      if ((event.ctrlKey || event.metaKey) && event.key === 'v') {
+        try {
+          // 클립보드 API 사용 (더 현대적인 방법)
+          if (navigator.clipboard && navigator.clipboard.read) {
+            const clipboardItems = await navigator.clipboard.read();
+            
+            for (const clipboardItem of clipboardItems) {
+              for (const type of clipboardItem.types) {
+                if (type.startsWith('image/')) {
+                  const blob = await clipboardItem.getType(type);
+                  const file = new File([blob], `clipboard-image-${Date.now()}.${type.split('/')[1]}`, { type });
+                  
+                  if (onImageUpload && editor) {
+                    const fileList = new DataTransfer();
+                    fileList.items.add(file);
+                    
+                    try {
+                      setIsUploading(true);
+                      const urls = await onImageUpload(fileList.files);
+                      if (urls && urls.length > 0) {
+                        // 기본 붙여넣기 동작 방지
+                        event.preventDefault();
+                        urls.forEach((url) => {
+                          editor.chain().focus().setImage({ src: url }).run();
+                        });
+                      }
+                    } catch (error) {
+                      console.error("Clipboard image upload failed:", error);
+                      alert("클립보드 이미지 업로드에 실패했습니다.");
+                    } finally {
+                      setIsUploading(false);
+                    }
+                  }
+                  return;
+                }
+              }
+            }
+          }
+        } catch (error) {
+          // 클립보드 API가 지원되지 않거나 권한이 없는 경우
+          // handlePaste에서 처리됨
+          console.debug("Clipboard API not available, falling back to paste event handler");
+        }
+      }
+    };
+
+    if (editor) {
+      const editorElement = editor.view.dom;
+      editorElement.addEventListener('keydown', handleKeyDown);
+      
+      return () => {
+        editorElement.removeEventListener('keydown', handleKeyDown);
+      };
+    }
+  }, [editor, onImageUpload]);
+
   // 툴바의 이미지 버튼을 통해 업로드하는 경우
   const handleToolbarImageUpload = useCallback(
     async (event) => {
       if (event.target.files && onImageUpload && editor) {
         try {
+          setIsUploading(true);
           const urls = await onImageUpload(event.target.files);
           if (urls && urls.length > 0) {
             urls.forEach((url) => {
@@ -102,6 +226,8 @@ export const CustomTiptapEditor = ({
         } catch (error) {
           console.error("Image upload failed:", error);
           alert("이미지 업로드에 실패했습니다.");
+        } finally {
+          setIsUploading(false);
         }
       }
     },
@@ -114,7 +240,7 @@ export const CustomTiptapEditor = ({
 
   return (
     <div 
-      className="custom-editor border rounded"
+      className={`custom-editor border rounded ${isUploading ? 'uploading' : ''}`}
       style={{ maxHeight: `${maxHeight}px` }}
     >
       <div className="toolbar-container">

--- a/src/hooks/useImageUpload.js
+++ b/src/hooks/useImageUpload.js
@@ -40,15 +40,28 @@ export const useImageUpload = (initialImageUrls = []) => {
   const handleUpload = useCallback(async (files) => {
     if (!files || files.length === 0) return [];
 
-    const newUrls = [];
-
     const imageFiles = Array.from(files).filter((f) =>
       f.type.startsWith("image/")
     );
 
+    if (imageFiles.length === 0) {
+      console.warn("업로드할 이미지 파일이 없습니다.");
+      return [];
+    }
+
     try {
       const urls = await Promise.all(
-        imageFiles.map((file) => uploadPostImage(file))
+        imageFiles.map((file) => {
+          if (!file.name) {
+            const timestamp = new Date().getTime();
+            const extension = file.type.split('/')[1] || 'png';
+            Object.defineProperty(file, 'name', {
+              writable: true,
+              value: `clipboard-image-${timestamp}.${extension}`
+            });
+          }
+          return uploadPostImage(file);
+        })
       );
       setImageUrls((prev) => [...prev, ...urls]);
       return urls;

--- a/src/styles/components/common/PostContent.css
+++ b/src/styles/components/common/PostContent.css
@@ -1,5 +1,5 @@
 .post-content-body img {
-  max-width: 50%;
+  max-width: 100%;
   height: auto;
   margin: 1rem 0;
   border-radius: 0.25rem;

--- a/src/styles/components/editor/editor.css
+++ b/src/styles/components/editor/editor.css
@@ -1,7 +1,27 @@
 /* Basic editor styles */
+.custom-editor {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.custom-editor .toolbar-container {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: white;
+  border-bottom: 1px solid #dee2e6;
+  flex-shrink: 0;
+}
+
+.custom-editor .editor-content {
+  flex: 1;
+  overflow-y: auto;
+}
+
 .ProseMirror {
-  min-height: 300px;
   padding: 0.75rem;
+  outline: none;
 }
 
 .ProseMirror:focus {
@@ -24,6 +44,7 @@ pre {
   font-family: "JetBrainsMono", monospace;
   padding: 0.75rem 1rem;
   border-radius: 0.5rem;
+  overflow-x: auto;
 }
 
 pre code {
@@ -58,14 +79,34 @@ img {
 }
 
 .custom-editor img {
-  max-width: 30%;
-  height: auto;}
+  max-width: 100%;
+  height: auto;
+}
 
 img.ProseMirror-selectednode {
   outline: 3px solid #68cef8;
 }
 
-/* Add styles for rich text formatting */
+/* 스크롤바 스타일링 */
+.custom-editor .editor-content::-webkit-scrollbar {
+  width: 8px;
+}
+
+.custom-editor .editor-content::-webkit-scrollbar-track {
+  background: #f1f1f1;
+  border-radius: 4px;
+}
+
+.custom-editor .editor-content::-webkit-scrollbar-thumb {
+  background: #c1c1c1;
+  border-radius: 4px;
+}
+
+.custom-editor .editor-content::-webkit-scrollbar-thumb:hover {
+  background: #a8a8a8;
+}
+
+/* Rich text formatting styles */
 .ProseMirror h1,
 .ProseMirror h2,
 .ProseMirror h3,
@@ -122,4 +163,32 @@ img.ProseMirror-selectednode {
 
 .ProseMirror li > p {
   margin-bottom: 0.25em;
+}
+
+/* 반응형 디자인 */
+@media (max-width: 768px) {
+  .custom-editor.scrollable-editor {
+    max-height: 60vh;
+  }
+  
+  .ProseMirror {
+    min-height: 150px;
+    padding: 0.5rem;
+  }
+  
+  .toolbar-container {
+    padding: 0.25rem;
+  }
+}
+
+/* 드래그 앤 드롭 스타일 */
+.ProseMirror.drag-over {
+  border: 2px dashed #007bff;
+  background-color: #f8f9fa;
+}
+
+/* 포커스 상태 */
+.custom-editor:focus-within {
+  border-color: #007bff;
+  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
 }

--- a/src/styles/components/editor/editor.css
+++ b/src/styles/components/editor/editor.css
@@ -192,3 +192,42 @@ img.ProseMirror-selectednode {
   border-color: #007bff;
   box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
 }
+
+/* 클립보드 이미지 붙여넣기 힌트 */
+.ProseMirror::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+  opacity: 0;
+  background: linear-gradient(45deg, transparent 49%, rgba(0, 123, 255, 0.1) 50%, transparent 51%);
+  transition: opacity 0.2s ease;
+}
+
+.ProseMirror.paste-active::after {
+  opacity: 1;
+}
+
+/* 간단한 이미지 업로드 텍스트 표시 */
+.custom-editor.uploading {
+  position: relative;
+}
+
+.custom-editor.uploading::before {
+  content: '이미지 업로드 중...';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(0, 0, 0, 0.8);
+  color: white;
+  padding: 8px 16px;
+  border-radius: 4px;
+  z-index: 1000;
+  font-size: 14px;
+  font-weight: 500;
+  white-space: nowrap;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#125 

## 📝작업 내용

- 에디터 글의 길이가 길어지면 스크롤되게 변경
  
<img width="692" height="858" alt="image" src="https://github.com/user-attachments/assets/f3bf961f-903a-458b-9a5c-a5ad0a950f6e" />

- 에디터에 클립보드 이미지 붙여넣기 기능 추가
![제목 없는 동영상 - Clipchamp로 제작 (3)](https://github.com/user-attachments/assets/a54749f3-4365-4cef-8915-1bf804d38995)

## ✅ 체크리스트

- [ ] 코드 점검 완료했습니다
- [ ] 문서/주석 최신화 완료했습니다
